### PR TITLE
Fix UL TBS bitflip error

### DIFF
--- a/lib/src/phy/phch/ra_ul.c
+++ b/lib/src/phy/phch/ra_ul.c
@@ -286,6 +286,8 @@ int srsran_ra_ul_dci_to_grant(srsran_cell_t*              cell,
                               srsran_dci_ul_t*            dci,
                               srsran_pusch_grant_t*       grant)
 {
+  bzero(grant, sizeof(srsran_pusch_grant_t));
+
   // Compute PRB allocation
   if (!ra_ul_grant_to_grant_prb_allocation(dci, grant, hopping_cfg->n_rb_ho, cell->nof_prb)) {
     // copy default values from DCI. RV can be updated by ul_fill_ra_mcs() in case of Adaptive retx (mcs>28)


### PR DESCRIPTION
When recording DCI data of multiple RNTIs (setting `decode_single_ue=false`), it seems like bitflip errors occur in the UL TBS field of decoded DCIs.

I've debugged the error a bit further:

When decoding the DCI, on the DL-side the function [srsran_ngscope_unpack_dl_dci_2grant](https://github.com/YaxiongXiePrinceton/NG-Scope/blob/3abeb1de50f3913e804801673aa9a5f3d964345e/lib/src/phy/ue/ngscope_dci.c#L7) calls two srsran functions to decode the DCI (passing references to the target structs as parameters). Both of these functions execute `bzero(...)` on the input parameters that they are about to write data into.

On the UL-side, the function [srsran_ngscope_unpack_ul_dci_2grant](https://github.com/YaxiongXiePrinceton/NG-Scope/blob/3abeb1de50f3913e804801673aa9a5f3d964345e/lib/src/phy/ue/ngscope_dci.c#L100) also calls two srsan functions to decode the DCI UL. But, the second function (that translates from `dci_ul` to `dci_ul_grant`) does not clear/initialize the target `grant` parameter (it does not call `bzero(...)`).

I found this to be the cause for random UL TBS appearing in decoded DCI that look like bitflip errors.

---

Additionally, I was a bit surprised that the `targetRNTI` variable is also used in the `decode_single_ue=false`-mode. More specifically, in the dci_decoder [here](https://github.com/YaxiongXiePrinceton/NG-Scope/blob/3abeb1de50f3913e804801673aa9a5f3d964345e/ngscope/src/dciLib/dci_decoder.c#L301). It is then finally used [here](https://github.com/YaxiongXiePrinceton/NG-Scope/blob/3abeb1de50f3913e804801673aa9a5f3d964345e/lib/src/phy/ue/ngscope_tree.c#L517). In my experiments, I do only retrieve other RNTIs DCI UL data when uncommenting the if-clause here. I think I might not see the the bigger picture here, can you maybe help me understanding why there is such a filter for the targetRNTI?
I could also open an additional PR for this second topic.

Looking forward to your feedback & let me know if u have any comments on my changes!